### PR TITLE
Fixed the Github test for the api call for user commits

### DIFF
--- a/test/test-case/interface/github.js
+++ b/test/test-case/interface/github.js
@@ -89,7 +89,10 @@
           var payload = event.payload;
           Should.exist(payload);
 
-          if(event.type == 'PushEvent') {
+          // If a PushEvent has no size, there are no commits to be read.
+          // This can happen if a file was added directly through Github,
+          // e.g. adding License.md
+          if(event.type == 'PushEvent' && payload.size !== 0) {
             var commits = payload.commits;
             commits.length.should.be.above(0);
           }


### PR DESCRIPTION
The Github test for the API call for user commits fails on some PushEvents. I believe some PushEvents (such as creating a file within Github web) can register as a PushEvent but does not register commits. See: https://github.com/jibarra/english-sanguosha/commit/c509b8aca6754f584b01cb3d01c5382ed16a6fb7

This should fix the test failing if a user has PushEvents with no commits.